### PR TITLE
fix: prevent pollNext() from blocking indefinitely on low-volume topics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.iggy.flink</groupId>
     <artifactId>flink-connector-iggy</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
     <name>Flink Connector for Apache Iggy</name>
 
     <properties>

--- a/src/main/java/org/apache/flink/connector/iggy/IggyDynamicTableFactory.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggyDynamicTableFactory.java
@@ -10,6 +10,7 @@ import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -53,6 +54,10 @@ public class IggyDynamicTableFactory implements DynamicTableSourceFactory {
             .key("tls").booleanType().defaultValue(false);
     public static final ConfigOption<String> TLS_CERTIFICATE = ConfigOptions
             .key("tls.certificate").stringType().noDefaultValue();
+    public static final ConfigOption<Long> POLL_TIMEOUT = ConfigOptions
+            .key("poll.timeout").longType().defaultValue(5000L)
+            .withDescription("Timeout in milliseconds for each poll call to Iggy. "
+                    + "Prevents blocking on empty partitions.");
 
     @Override
     public String factoryIdentifier() {
@@ -76,6 +81,7 @@ public class IggyDynamicTableFactory implements DynamicTableSourceFactory {
         options.add(PASSWORD);
         options.add(TLS);
         options.add(TLS_CERTIFICATE);
+        options.add(POLL_TIMEOUT);
         options.add(FactoryUtil.FORMAT);
         return options;
     }
@@ -98,10 +104,12 @@ public class IggyDynamicTableFactory implements DynamicTableSourceFactory {
         String topic = helper.getOptions().get(TOPIC);
         boolean tlsEnabled = helper.getOptions().get(TLS);
         String tlsCert = helper.getOptions().get(TLS_CERTIFICATE);
+        long pollTimeoutMs = helper.getOptions().get(POLL_TIMEOUT);
 
         return new IggyDynamicTableSource(
                 host, port, username, password, stream, topic,
                 tlsEnabled, tlsCert,
+                Duration.ofMillis(pollTimeoutMs),
                 decodingFormat,
                 context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType());
     }

--- a/src/main/java/org/apache/flink/connector/iggy/IggyDynamicTableSource.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggyDynamicTableSource.java
@@ -10,6 +10,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.RowKind;
 
+import java.time.Duration;
+
 /**
  * Scan table source for Apache Iggy.
  */
@@ -23,6 +25,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
     private final String topic;
     private final boolean tls;
     private final String tlsCertificatePath;
+    private final Duration pollTimeout;
     private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
     private final DataType physicalDataType;
 
@@ -31,6 +34,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
             String username, String password,
             String stream, String topic,
             boolean tls, String tlsCertificatePath,
+            Duration pollTimeout,
             DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
             DataType physicalDataType) {
         this.host = host;
@@ -41,6 +45,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
         this.topic = topic;
         this.tls = tls;
         this.tlsCertificatePath = tlsCertificatePath;
+        this.pollTimeout = pollTimeout;
         this.decodingFormat = decodingFormat;
         this.physicalDataType = physicalDataType;
     }
@@ -65,6 +70,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
                 .setCredentials(username, password)
                 .setStream(stream)
                 .setTopic(topic)
+                .setPollTimeout(pollTimeout)
                 .setDeserializer(iggySchema);
 
         if (tls) {
@@ -81,7 +87,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
     public DynamicTableSource copy() {
         return new IggyDynamicTableSource(
                 host, port, username, password, stream, topic,
-                tls, tlsCertificatePath, decodingFormat, physicalDataType);
+                tls, tlsCertificatePath, pollTimeout, decodingFormat, physicalDataType);
     }
 
     @Override

--- a/src/main/java/org/apache/flink/connector/iggy/IggySource.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggySource.java
@@ -37,6 +37,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
     private final String topicId;
     private final Duration discoveryInterval;
     private final Duration pollBackoff;
+    private final Duration pollTimeout;
     private final int batchSize;
     private final long consumerId;
     private final IggyDeserializationSchema<T> deserializer;
@@ -48,6 +49,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
         this.topicId = Preconditions.checkNotNull(b.topicId, "Topic must be set");
         this.discoveryInterval = Preconditions.checkNotNull(b.discoveryInterval);
         this.pollBackoff = Preconditions.checkNotNull(b.pollBackoff);
+        this.pollTimeout = Preconditions.checkNotNull(b.pollTimeout);
         this.batchSize = b.batchSize;
         this.consumerId = b.consumerId;
         this.deserializer = Preconditions.checkNotNull(b.deserializer, "Deserializer must be set");
@@ -75,7 +77,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
     public SourceReader<T, IggySplit> createReader(SourceReaderContext readerContext) {
         return new IggySourceReader<>(
                 readerContext, connectionConfig, pollBackoff.toMillis(),
-                batchSize, consumerId, deserializer);
+                pollTimeout.toMillis(), batchSize, consumerId, deserializer);
     }
 
     @Override
@@ -117,6 +119,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
         private String tlsCertificatePath;
         private Duration discoveryInterval = Duration.ofMinutes(1);
         private Duration pollBackoff = Duration.ofMillis(100);
+        private Duration pollTimeout = Duration.ofSeconds(5);
         private int batchSize = 100;
         private long consumerId = 1L;
         private IggyDeserializationSchema<T> deserializer;
@@ -135,6 +138,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
         public Builder<T> setTlsCertificate(String path) { this.tlsCertificatePath = path; return this; }
         public Builder<T> setDiscoveryInterval(Duration interval) { this.discoveryInterval = interval; return this; }
         public Builder<T> setPollBackoff(Duration backoff) { this.pollBackoff = backoff; return this; }
+        public Builder<T> setPollTimeout(Duration timeout) { this.pollTimeout = timeout; return this; }
         public Builder<T> setBatchSize(int batchSize) {
             Preconditions.checkArgument(batchSize > 0, "Batch size must be positive");
             this.batchSize = batchSize; return this;

--- a/src/main/java/org/apache/flink/connector/iggy/IggySourceReader.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggySourceReader.java
@@ -21,7 +21,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Pulls data from Iggy partitions using round-robin polling with non-blocking backoff.
@@ -35,12 +39,14 @@ public class IggySourceReader<T> implements SourceReader<T, IggySplit> {
     private final SourceReaderContext context;
     private final IggyConnectionConfig connectionConfig;
     private final long pollBackoffMs;
+    private final long pollTimeoutMs;
     private final int batchSize;
     private final long consumerId;
     private final IggyDeserializationSchema<T> deserializer;
 
     // Accessed only from the Flink mailbox thread.
     private IggyTcpClient client;
+    private ExecutorService pollExecutor;
     private final List<IggySplit> assignedSplits = new ArrayList<>();
     private CompletableFuture<Void> availability = new CompletableFuture<>();
     private int nextSplitIndex;
@@ -52,12 +58,14 @@ public class IggySourceReader<T> implements SourceReader<T, IggySplit> {
             SourceReaderContext context,
             IggyConnectionConfig connectionConfig,
             long pollBackoffMs,
+            long pollTimeoutMs,
             int batchSize,
             long consumerId,
             IggyDeserializationSchema<T> deserializer) {
         this.context = context;
         this.connectionConfig = connectionConfig;
         this.pollBackoffMs = pollBackoffMs;
+        this.pollTimeoutMs = pollTimeoutMs;
         this.batchSize = batchSize;
         this.consumerId = consumerId;
         this.deserializer = deserializer;
@@ -65,9 +73,15 @@ public class IggySourceReader<T> implements SourceReader<T, IggySplit> {
 
     @Override
     public void start() {
-        LOG.info("Connecting to Iggy at {}:{}", connectionConfig.host(), connectionConfig.port());
+        LOG.info("Connecting to Iggy at {}:{} (poll timeout {}ms)",
+                connectionConfig.host(), connectionConfig.port(), pollTimeoutMs);
         numRecordsIn = context.metricGroup().counter("numRecordsIn");
         numBytesIn = context.metricGroup().counter("numBytesIn");
+        this.pollExecutor = Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "iggy-poll");
+            t.setDaemon(true);
+            return t;
+        });
         try {
             this.client = connectionConfig.connect();
             this.deserializer.open(context.metricGroup());
@@ -88,17 +102,26 @@ public class IggySourceReader<T> implements SourceReader<T, IggySplit> {
 
             PolledMessages polled;
             try {
-                polled = client.messages().pollMessages(
-                        StreamId.of(split.getStreamId()),
-                        TopicId.of(split.getTopicId()),
-                        Optional.of((long) split.getPartitionId()),
-                        Consumer.of(consumerId),
-                        PollingStrategy.offset(BigInteger.valueOf(split.getCurrentOffset())),
-                        (long) batchSize,
-                        false);
-            } catch (Exception e) {
-                LOG.warn("Poll failed for {}, will retry on next cycle", split.splitId(), e);
+                CompletableFuture<PolledMessages> future = CompletableFuture.supplyAsync(
+                        () -> client.messages().pollMessages(
+                                StreamId.of(split.getStreamId()),
+                                TopicId.of(split.getTopicId()),
+                                Optional.of((long) split.getPartitionId()),
+                                Consumer.of(consumerId),
+                                PollingStrategy.offset(BigInteger.valueOf(split.getCurrentOffset())),
+                                (long) batchSize,
+                                false),
+                        pollExecutor);
+                polled = future.get(pollTimeoutMs, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException e) {
+                LOG.debug("Poll timed out for {}, partition likely empty", split.splitId());
                 continue;
+            } catch (ExecutionException e) {
+                LOG.warn("Poll failed for {}, will retry on next cycle", split.splitId(), e.getCause());
+                continue;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return InputStatus.NOTHING_AVAILABLE;
             }
 
             if (!polled.messages().isEmpty()) {
@@ -145,6 +168,9 @@ public class IggySourceReader<T> implements SourceReader<T, IggySplit> {
 
     @Override
     public void close() {
+        if (pollExecutor != null) {
+            pollExecutor.shutdownNow();
+        }
         // IggyTcpClient 0.7.0 has no close/shutdown — relies on GC.
         // Monitor thread counts in long-running jobs.
         client = null;

--- a/src/test/java/org/apache/flink/connector/iggy/IggyDynamicTableFactoryTest.java
+++ b/src/test/java/org/apache/flink/connector/iggy/IggyDynamicTableFactoryTest.java
@@ -40,4 +40,16 @@ class IggyDynamicTableFactoryTest {
         assertEquals("iggy", IggyDynamicTableFactory.PASSWORD.defaultValue());
         assertEquals(false, IggyDynamicTableFactory.TLS.defaultValue());
     }
+
+    @Test
+    void shouldHaveDefaultPollTimeout() {
+        assertEquals(5000L, IggyDynamicTableFactory.POLL_TIMEOUT.defaultValue());
+    }
+
+    @Test
+    void shouldExposePollTimeoutAsOptional() {
+        var factory = new IggyDynamicTableFactory();
+        var keys = factory.optionalOptions().stream().map(o -> o.key()).toList();
+        assertTrue(keys.contains("poll.timeout"));
+    }
 }

--- a/src/test/java/org/apache/flink/connector/iggy/IggySourceReaderTest.java
+++ b/src/test/java/org/apache/flink/connector/iggy/IggySourceReaderTest.java
@@ -25,7 +25,7 @@ class IggySourceReaderTest {
 
     static IggySourceReader<byte[]> createReader() {
         var config = new IggyConnectionConfig(HOST, PORT, "iggy", "iggy", false, null);
-        return new IggySourceReader<>(new StubSourceReaderContext(), config, 100L, 100, 1L, payload -> payload);
+        return new IggySourceReader<>(new StubSourceReaderContext(), config, 100L, 5000L, 100, 1L, payload -> payload);
     }
 
     @Test

--- a/src/test/java/org/apache/flink/connector/iggy/IggySplitEnumeratorTest.java
+++ b/src/test/java/org/apache/flink/connector/iggy/IggySplitEnumeratorTest.java
@@ -32,7 +32,7 @@ class IggySplitEnumeratorTest {
         var config = new IggyConnectionConfig(HOST, PORT, "iggy", "iggy", false, null);
         var reader = new IggySourceReader<byte[]>(
                 new IggySourceReaderTest.StubSourceReaderContext(),
-                config, 100L, 100, 1L, payload -> payload);
+                config, 100L, 5000L, 100, 1L, payload -> payload);
         reader.start();
         reader.addSplits(List.of(
                 new IggySplit("crypto", "prices", 0, 0),

--- a/src/test/java/org/apache/flink/connector/iggy/IggyTestcontainersTest.java
+++ b/src/test/java/org/apache/flink/connector/iggy/IggyTestcontainersTest.java
@@ -67,7 +67,7 @@ class IggyTestcontainersTest {
     void shouldReadAllMessages() throws Exception {
         var reader = new IggySourceReader<byte[]>(
                 new IggySourceReaderTest.StubSourceReaderContext(),
-                config, 100L, 100, 1L, payload -> payload);
+                config, 100L, 5000L, 100, 1L, payload -> payload);
         reader.start();
         reader.addSplits(Collections.singletonList(new IggySplit("test-stream", "test-topic", 0, 0)));
 


### PR DESCRIPTION
Wrap the blocking IggyTcpClient.pollMessages() call in a CompletableFuture with a configurable timeout (default 5 seconds). This prevents the Flink mailbox thread from being blocked when a partition has no new data, allowing checkpoints, watermarks, and cancel signals to be processed normally.

- Add pollTimeoutMs to IggySourceReader; offload the blocking SDK call to a daemon-threaded executor with Future.get(timeout)
- Expose setPollTimeout(Duration) on IggySource.Builder
- Add 'poll.timeout' SQL table option (IggyDynamicTableFactory)
- Shut down poll executor in IggySourceReader.close()
- Bump version to 0.1.1-SNAPSHOT
- Update all test call sites for the new constructor parameter

Closes #1