### PR TITLE
feat: add configurable starting offset policy for new splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,37 @@ Connection properties (with defaults):
 | `password` | `iggy` | No |
 | `tls` | `false` | No |
 | `tls.certificate` | — | No |
+| `starting-offset` | `earliest` | No |
+| `poll.timeout` | `5000` | No |
+
+The `starting-offset` property controls where new splits begin consuming:
+- `earliest` (default) — start from the beginning of the partition
+- `latest` — start from the current end, skipping existing messages
+- `specific-offset:<long>` — start from a specific offset (e.g., `specific-offset:48291`)
+
+```sql
+-- Start from latest (skip historical messages)
+CREATE TABLE iggy_traffic (
+  ...
+) WITH (
+  'connector'       = 'iggy',
+  'stream'          = 'web-traffic',
+  'topic'           = 'requests',
+  'format'          = 'json',
+  'starting-offset' = 'latest'
+);
+
+-- Start from a specific offset (replay use case)
+CREATE TABLE iggy_traffic_replay (
+  ...
+) WITH (
+  'connector'       = 'iggy',
+  'stream'          = 'web-traffic',
+  'topic'           = 'requests',
+  'format'          = 'json',
+  'starting-offset' = 'specific-offset:48291'
+);
+```
 
 **Note:** When running Flink in Docker, set `'host'` to the Iggy container name
 (e.g., `'host' = 'iggy'`), not `localhost`.
@@ -115,6 +146,26 @@ IggySource<MyPojo> source = IggySource.<MyPojo>builder()
     .setStream("crypto")
     .setTopic("prices")
     .setDeserializer(bytes -> objectMapper.readValue(bytes, MyPojo.class))
+    .build();
+```
+
+### DataStream API (with starting offset)
+
+```java
+// Start from latest — skip all existing messages
+IggySource<byte[]> latestSource = IggySource.<byte[]>builder()
+    .setStream("crypto")
+    .setTopic("prices")
+    .setDeserializer(payload -> payload)
+    .setStartingOffset(IggyOffsetSpec.latest())
+    .build();
+
+// Start from a specific offset — replay use case
+IggySource<byte[]> replaySource = IggySource.<byte[]>builder()
+    .setStream("crypto")
+    .setTopic("prices")
+    .setDeserializer(payload -> payload)
+    .setStartingOffset(IggyOffsetSpec.specificOffset(48291L))
     .build();
 ```
 

--- a/src/main/java/org/apache/flink/connector/iggy/IggyDynamicTableFactory.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggyDynamicTableFactory.java
@@ -58,6 +58,10 @@ public class IggyDynamicTableFactory implements DynamicTableSourceFactory {
             .key("poll.timeout").longType().defaultValue(5000L)
             .withDescription("Timeout in milliseconds for each poll call to Iggy. "
                     + "Prevents blocking on empty partitions.");
+    public static final ConfigOption<String> STARTING_OFFSET = ConfigOptions
+            .key("starting-offset").stringType().defaultValue("earliest")
+            .withDescription("Starting offset policy for new splits: "
+                    + "'earliest', 'latest', or 'specific-offset:<long>'.");
 
     @Override
     public String factoryIdentifier() {
@@ -82,6 +86,7 @@ public class IggyDynamicTableFactory implements DynamicTableSourceFactory {
         options.add(TLS);
         options.add(TLS_CERTIFICATE);
         options.add(POLL_TIMEOUT);
+        options.add(STARTING_OFFSET);
         options.add(FactoryUtil.FORMAT);
         return options;
     }
@@ -105,12 +110,39 @@ public class IggyDynamicTableFactory implements DynamicTableSourceFactory {
         boolean tlsEnabled = helper.getOptions().get(TLS);
         String tlsCert = helper.getOptions().get(TLS_CERTIFICATE);
         long pollTimeoutMs = helper.getOptions().get(POLL_TIMEOUT);
+        IggyOffsetSpec offsetSpec = parseStartingOffset(helper.getOptions().get(STARTING_OFFSET));
 
         return new IggyDynamicTableSource(
                 host, port, username, password, stream, topic,
                 tlsEnabled, tlsCert,
                 Duration.ofMillis(pollTimeoutMs),
+                offsetSpec,
                 decodingFormat,
                 context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType());
+    }
+
+    static IggyOffsetSpec parseStartingOffset(String value) {
+        if (value == null || value.isBlank()) {
+            return IggyOffsetSpec.earliest();
+        }
+        String trimmed = value.trim().toLowerCase();
+        if ("earliest".equals(trimmed)) {
+            return IggyOffsetSpec.earliest();
+        }
+        if ("latest".equals(trimmed)) {
+            return IggyOffsetSpec.latest();
+        }
+        if (trimmed.startsWith("specific-offset:")) {
+            String offsetStr = trimmed.substring("specific-offset:".length()).trim();
+            try {
+                return IggyOffsetSpec.specificOffset(Long.parseLong(offsetStr));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                        "Invalid specific-offset value: '" + offsetStr + "'. Expected a long.", e);
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unknown starting-offset value: '" + value
+                        + "'. Expected 'earliest', 'latest', or 'specific-offset:<long>'.");
     }
 }

--- a/src/main/java/org/apache/flink/connector/iggy/IggyDynamicTableSource.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggyDynamicTableSource.java
@@ -26,6 +26,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
     private final boolean tls;
     private final String tlsCertificatePath;
     private final Duration pollTimeout;
+    private final IggyOffsetSpec offsetSpec;
     private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
     private final DataType physicalDataType;
 
@@ -35,6 +36,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
             String stream, String topic,
             boolean tls, String tlsCertificatePath,
             Duration pollTimeout,
+            IggyOffsetSpec offsetSpec,
             DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
             DataType physicalDataType) {
         this.host = host;
@@ -46,6 +48,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
         this.tls = tls;
         this.tlsCertificatePath = tlsCertificatePath;
         this.pollTimeout = pollTimeout;
+        this.offsetSpec = offsetSpec;
         this.decodingFormat = decodingFormat;
         this.physicalDataType = physicalDataType;
     }
@@ -71,6 +74,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
                 .setStream(stream)
                 .setTopic(topic)
                 .setPollTimeout(pollTimeout)
+                .setStartingOffset(offsetSpec)
                 .setDeserializer(iggySchema);
 
         if (tls) {
@@ -87,7 +91,7 @@ public class IggyDynamicTableSource implements ScanTableSource {
     public DynamicTableSource copy() {
         return new IggyDynamicTableSource(
                 host, port, username, password, stream, topic,
-                tls, tlsCertificatePath, pollTimeout, decodingFormat, physicalDataType);
+                tls, tlsCertificatePath, pollTimeout, offsetSpec, decodingFormat, physicalDataType);
     }
 
     @Override

--- a/src/main/java/org/apache/flink/connector/iggy/IggyOffsetPolicy.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggyOffsetPolicy.java
@@ -1,0 +1,23 @@
+package org.apache.flink.connector.iggy;
+
+/**
+ * Supported starting offset strategies for new splits.
+ *
+ * <p>Controls where a new Flink job (or a job restored from a savepoint with
+ * explicit offset seek) begins consuming. Restored splits from checkpoints
+ * always use their persisted offsets regardless of this setting.
+ */
+public enum IggyOffsetPolicy {
+
+    /** Start from the first available message in the partition. */
+    EARLIEST,
+
+    /** Start from the next message to be written (skip all existing messages). */
+    LATEST,
+
+    /**
+     * Start from a specific offset value.
+     * Requires {@link IggyOffsetSpec#specificOffset(long)} to be set.
+     */
+    SPECIFIC_OFFSET
+}

--- a/src/main/java/org/apache/flink/connector/iggy/IggyOffsetSpec.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggyOffsetSpec.java
@@ -1,0 +1,48 @@
+package org.apache.flink.connector.iggy;
+
+import java.io.Serializable;
+
+/**
+ * Immutable value object pairing an {@link IggyOffsetPolicy} with its optional argument.
+ *
+ * <p>Used to configure where new splits begin consuming. Restored splits from
+ * checkpoints always use their persisted offsets and ignore this spec.
+ */
+public final class IggyOffsetSpec implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final IggyOffsetPolicy policy;
+    private final long specificOffset;
+
+    private IggyOffsetSpec(IggyOffsetPolicy policy, long specificOffset) {
+        this.policy = policy;
+        this.specificOffset = specificOffset;
+    }
+
+    /** Start from the first available message (offset 0). */
+    public static IggyOffsetSpec earliest() {
+        return new IggyOffsetSpec(IggyOffsetPolicy.EARLIEST, 0L);
+    }
+
+    /** Start from the current end of the partition, skipping all existing messages. */
+    public static IggyOffsetSpec latest() {
+        return new IggyOffsetSpec(IggyOffsetPolicy.LATEST, -1L);
+    }
+
+    /** Start from a specific offset value. */
+    public static IggyOffsetSpec specificOffset(long offset) {
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must be >= 0, got: " + offset);
+        }
+        return new IggyOffsetSpec(IggyOffsetPolicy.SPECIFIC_OFFSET, offset);
+    }
+
+    public IggyOffsetPolicy getPolicy() {
+        return policy;
+    }
+
+    public long getSpecificOffset() {
+        return specificOffset;
+    }
+}

--- a/src/main/java/org/apache/flink/connector/iggy/IggySource.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggySource.java
@@ -41,6 +41,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
     private final int batchSize;
     private final long consumerId;
     private final IggyDeserializationSchema<T> deserializer;
+    private final IggyOffsetSpec offsetSpec;
 
     private IggySource(Builder<T> b) {
         this.connectionConfig = new IggyConnectionConfig(
@@ -53,6 +54,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
         this.batchSize = b.batchSize;
         this.consumerId = b.consumerId;
         this.deserializer = Preconditions.checkNotNull(b.deserializer, "Deserializer must be set");
+        this.offsetSpec = b.offsetSpec != null ? b.offsetSpec : IggyOffsetSpec.earliest();
     }
 
     public static <T> Builder<T> builder() {
@@ -85,7 +87,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
             SplitEnumeratorContext<IggySplit> enumContext) {
         return new IggySplitEnumerator(
                 enumContext, connectionConfig, streamId, topicId,
-                discoveryInterval.toMillis());
+                discoveryInterval.toMillis(), offsetSpec);
     }
 
     @Override
@@ -94,7 +96,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
             IggyEnumeratorState checkpoint) {
         return new IggySplitEnumerator(
                 enumContext, connectionConfig, streamId, topicId,
-                discoveryInterval.toMillis(), checkpoint);
+                discoveryInterval.toMillis(), offsetSpec, checkpoint);
     }
 
     @Override
@@ -123,6 +125,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
         private int batchSize = 100;
         private long consumerId = 1L;
         private IggyDeserializationSchema<T> deserializer;
+        private IggyOffsetSpec offsetSpec;
 
         public Builder<T> setHost(String host) { this.host = host; return this; }
         public Builder<T> setPort(int port) {
@@ -145,6 +148,7 @@ public class IggySource<T> implements Source<T, IggySplit, IggyEnumeratorState>,
         }
         public Builder<T> setConsumerId(long consumerId) { this.consumerId = consumerId; return this; }
         public Builder<T> setDeserializer(IggyDeserializationSchema<T> d) { this.deserializer = d; return this; }
+        public Builder<T> setStartingOffset(IggyOffsetSpec offsetSpec) { this.offsetSpec = offsetSpec; return this; }
 
         public IggySource<T> build() {
             return new IggySource<>(this);

--- a/src/main/java/org/apache/flink/connector/iggy/IggySplitEnumerator.java
+++ b/src/main/java/org/apache/flink/connector/iggy/IggySplitEnumerator.java
@@ -6,16 +6,21 @@ import org.apache.iggy.client.blocking.tcp.IggyTcpClient;
 import org.apache.iggy.identifier.StreamId;
 import org.apache.iggy.identifier.TopicId;
 
+import org.apache.iggy.consumergroup.Consumer;
+import org.apache.iggy.message.PollingStrategy;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -31,6 +36,7 @@ public class IggySplitEnumerator implements SplitEnumerator<IggySplit, IggyEnume
     private final String streamId;
     private final String topicId;
     private final long discoveryIntervalMs;
+    private final IggyOffsetSpec offsetSpec;
 
     private IggyTcpClient client;
     private final List<IggySplit> unassignedSplits = new ArrayList<>();
@@ -42,11 +48,8 @@ public class IggySplitEnumerator implements SplitEnumerator<IggySplit, IggyEnume
             IggyConnectionConfig connectionConfig,
             String streamId, String topicId,
             long discoveryIntervalMs) {
-        this.context = context;
-        this.connectionConfig = connectionConfig;
-        this.streamId = streamId;
-        this.topicId = topicId;
-        this.discoveryIntervalMs = discoveryIntervalMs;
+        this(context, connectionConfig, streamId, topicId, discoveryIntervalMs,
+                IggyOffsetSpec.earliest());
     }
 
     IggySplitEnumerator(
@@ -54,12 +57,40 @@ public class IggySplitEnumerator implements SplitEnumerator<IggySplit, IggyEnume
             IggyConnectionConfig connectionConfig,
             String streamId, String topicId,
             long discoveryIntervalMs,
+            IggyOffsetSpec offsetSpec) {
+        this.context = context;
+        this.connectionConfig = connectionConfig;
+        this.streamId = streamId;
+        this.topicId = topicId;
+        this.discoveryIntervalMs = discoveryIntervalMs;
+        this.offsetSpec = offsetSpec != null ? offsetSpec : IggyOffsetSpec.earliest();
+    }
+
+    IggySplitEnumerator(
+            SplitEnumeratorContext<IggySplit> context,
+            IggyConnectionConfig connectionConfig,
+            String streamId, String topicId,
+            long discoveryIntervalMs,
+            IggyOffsetSpec offsetSpec,
             IggyEnumeratorState restored) {
-        this(context, connectionConfig, streamId, topicId, discoveryIntervalMs);
+        this(context, connectionConfig, streamId, topicId, discoveryIntervalMs, offsetSpec);
+        // Restored splits carry their persisted offsets from checkpoint.
+        // The offsetSpec is NOT applied here — it only affects newly discovered partitions.
         unassignedSplits.addAll(restored.assignedSplits());
         unassignedSplits.addAll(restored.unassignedSplits());
         unassignedSplits.forEach(s -> knownPartitions.add(s.getPartitionId()));
         LOG.info("Restored enumerator with {} splits", unassignedSplits.size());
+    }
+
+    // Keep backward-compatible restore constructor (used by existing callers)
+    IggySplitEnumerator(
+            SplitEnumeratorContext<IggySplit> context,
+            IggyConnectionConfig connectionConfig,
+            String streamId, String topicId,
+            long discoveryIntervalMs,
+            IggyEnumeratorState restored) {
+        this(context, connectionConfig, streamId, topicId, discoveryIntervalMs,
+                IggyOffsetSpec.earliest(), restored);
     }
 
     @Override
@@ -115,7 +146,11 @@ public class IggySplitEnumerator implements SplitEnumerator<IggySplit, IggyEnume
 
         for (var i = 0; i < partitionCount; i++) {
             if (knownPartitions.add(i)) {
-                unassignedSplits.add(new IggySplit(streamId, topicId, i, 0));
+                // offsetSpec is applied only to NEW splits created during partition discovery.
+                // Splits restored from checkpoint carry their persisted offsets and are not
+                // re-initialised here. See the restore constructor.
+                long startOffset = resolveStartingOffset(i);
+                unassignedSplits.add(new IggySplit(streamId, topicId, i, startOffset));
             }
         }
     }
@@ -134,13 +169,42 @@ public class IggySplitEnumerator implements SplitEnumerator<IggySplit, IggyEnume
         var added = 0;
         for (var i = 0; i < currentCount; i++) {
             if (knownPartitions.add(i)) {
-                unassignedSplits.add(new IggySplit(streamId, topicId, i, 0));
+                long startOffset = resolveStartingOffset(i);
+                unassignedSplits.add(new IggySplit(streamId, topicId, i, startOffset));
                 added++;
             }
         }
         if (added > 0) {
             LOG.info("Discovered {} new partition(s)", added);
             assignPendingSplits();
+        }
+    }
+
+    private long resolveStartingOffset(int partitionId) {
+        return switch (offsetSpec.getPolicy()) {
+            case EARLIEST -> 0L;
+            case LATEST -> fetchLatestOffset(partitionId);
+            case SPECIFIC_OFFSET -> offsetSpec.getSpecificOffset();
+        };
+    }
+
+    private long fetchLatestOffset(int partitionId) {
+        try {
+            var polled = client.messages().pollMessages(
+                    StreamId.of(streamId), TopicId.of(topicId),
+                    Optional.of((long) partitionId),
+                    Consumer.of(0L),
+                    PollingStrategy.last(),
+                    1L,
+                    false);
+            if (polled.messages().isEmpty()) {
+                return 0L;
+            }
+            // Next offset to be written = last message offset + 1
+            return polled.messages().get(0).header().offset().longValue() + 1;
+        } catch (Exception e) {
+            LOG.warn("Failed to fetch latest offset for partition {}, defaulting to 0", partitionId, e);
+            return 0L;
         }
     }
 

--- a/src/test/java/org/apache/flink/connector/iggy/IggyDynamicTableFactoryTest.java
+++ b/src/test/java/org/apache/flink/connector/iggy/IggyDynamicTableFactoryTest.java
@@ -52,4 +52,16 @@ class IggyDynamicTableFactoryTest {
         var keys = factory.optionalOptions().stream().map(o -> o.key()).toList();
         assertTrue(keys.contains("poll.timeout"));
     }
+
+    @Test
+    void shouldExposeStartingOffsetAsOptional() {
+        var factory = new IggyDynamicTableFactory();
+        var keys = factory.optionalOptions().stream().map(o -> o.key()).toList();
+        assertTrue(keys.contains("starting-offset"));
+    }
+
+    @Test
+    void shouldHaveDefaultStartingOffset() {
+        assertEquals("earliest", IggyDynamicTableFactory.STARTING_OFFSET.defaultValue());
+    }
 }

--- a/src/test/java/org/apache/flink/connector/iggy/IggyOffsetSpecTest.java
+++ b/src/test/java/org/apache/flink/connector/iggy/IggyOffsetSpecTest.java
@@ -1,0 +1,45 @@
+package org.apache.flink.connector.iggy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link IggyOffsetSpec} factory methods and validation. */
+class IggyOffsetSpecTest {
+
+    @Test
+    void earliestShouldReturnEarliestPolicy() {
+        var spec = IggyOffsetSpec.earliest();
+        assertEquals(IggyOffsetPolicy.EARLIEST, spec.getPolicy());
+        assertEquals(0L, spec.getSpecificOffset());
+    }
+
+    @Test
+    void latestShouldReturnLatestPolicy() {
+        var spec = IggyOffsetSpec.latest();
+        assertEquals(IggyOffsetPolicy.LATEST, spec.getPolicy());
+    }
+
+    @Test
+    void specificOffsetShouldStoreOffset() {
+        var spec = IggyOffsetSpec.specificOffset(42L);
+        assertEquals(IggyOffsetPolicy.SPECIFIC_OFFSET, spec.getPolicy());
+        assertEquals(42L, spec.getSpecificOffset());
+    }
+
+    @Test
+    void specificOffsetShouldAcceptZero() {
+        var spec = IggyOffsetSpec.specificOffset(0L);
+        assertEquals(0L, spec.getSpecificOffset());
+    }
+
+    @Test
+    void specificOffsetShouldRejectNegative() {
+        assertThrows(IllegalArgumentException.class, () -> IggyOffsetSpec.specificOffset(-1));
+    }
+
+    @Test
+    void specificOffsetShouldRejectLargeNegative() {
+        assertThrows(IllegalArgumentException.class, () -> IggyOffsetSpec.specificOffset(-100));
+    }
+}

--- a/src/test/java/org/apache/flink/connector/iggy/IggySourceBuilderTest.java
+++ b/src/test/java/org/apache/flink/connector/iggy/IggySourceBuilderTest.java
@@ -67,4 +67,36 @@ class IggySourceBuilderTest {
         assertNotNull(source);
         assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, source.getBoundedness());
     }
+
+    @Test
+    void shouldBuildWithStartingOffset() {
+        var source = IggySource.<byte[]>builder()
+                .setStream("s")
+                .setTopic("t")
+                .setDeserializer(payload -> payload)
+                .setStartingOffset(IggyOffsetSpec.latest())
+                .build();
+        assertNotNull(source);
+    }
+
+    @Test
+    void shouldBuildWithSpecificOffset() {
+        var source = IggySource.<byte[]>builder()
+                .setStream("s")
+                .setTopic("t")
+                .setDeserializer(payload -> payload)
+                .setStartingOffset(IggyOffsetSpec.specificOffset(500))
+                .build();
+        assertNotNull(source);
+    }
+
+    @Test
+    void shouldDefaultToEarliestWhenNotSet() {
+        var source = IggySource.<byte[]>builder()
+                .setStream("s")
+                .setTopic("t")
+                .setDeserializer(payload -> payload)
+                .build();
+        assertNotNull(source);
+    }
 }

--- a/src/test/java/org/apache/flink/connector/iggy/IggyStartingOffsetParsingTest.java
+++ b/src/test/java/org/apache/flink/connector/iggy/IggyStartingOffsetParsingTest.java
@@ -1,0 +1,73 @@
+package org.apache.flink.connector.iggy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for SQL starting-offset option parsing. */
+class IggyStartingOffsetParsingTest {
+
+    @Test
+    void shouldParseEarliest() {
+        var spec = IggyDynamicTableFactory.parseStartingOffset("earliest");
+        assertEquals(IggyOffsetPolicy.EARLIEST, spec.getPolicy());
+    }
+
+    @Test
+    void shouldParseLatest() {
+        var spec = IggyDynamicTableFactory.parseStartingOffset("latest");
+        assertEquals(IggyOffsetPolicy.LATEST, spec.getPolicy());
+    }
+
+    @Test
+    void shouldParseSpecificOffset() {
+        var spec = IggyDynamicTableFactory.parseStartingOffset("specific-offset:48291");
+        assertEquals(IggyOffsetPolicy.SPECIFIC_OFFSET, spec.getPolicy());
+        assertEquals(48291L, spec.getSpecificOffset());
+    }
+
+    @Test
+    void shouldParseSpecificOffsetZero() {
+        var spec = IggyDynamicTableFactory.parseStartingOffset("specific-offset:0");
+        assertEquals(IggyOffsetPolicy.SPECIFIC_OFFSET, spec.getPolicy());
+        assertEquals(0L, spec.getSpecificOffset());
+    }
+
+    @Test
+    void shouldBeCaseInsensitive() {
+        assertEquals(IggyOffsetPolicy.EARLIEST,
+                IggyDynamicTableFactory.parseStartingOffset("EARLIEST").getPolicy());
+        assertEquals(IggyOffsetPolicy.LATEST,
+                IggyDynamicTableFactory.parseStartingOffset("Latest").getPolicy());
+    }
+
+    @Test
+    void shouldDefaultToEarliestForNull() {
+        var spec = IggyDynamicTableFactory.parseStartingOffset(null);
+        assertEquals(IggyOffsetPolicy.EARLIEST, spec.getPolicy());
+    }
+
+    @Test
+    void shouldDefaultToEarliestForBlank() {
+        var spec = IggyDynamicTableFactory.parseStartingOffset("  ");
+        assertEquals(IggyOffsetPolicy.EARLIEST, spec.getPolicy());
+    }
+
+    @Test
+    void shouldRejectUnknownValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> IggyDynamicTableFactory.parseStartingOffset("unknown"));
+    }
+
+    @Test
+    void shouldRejectInvalidSpecificOffset() {
+        assertThrows(IllegalArgumentException.class,
+                () -> IggyDynamicTableFactory.parseStartingOffset("specific-offset:abc"));
+    }
+
+    @Test
+    void shouldRejectNegativeSpecificOffset() {
+        assertThrows(IllegalArgumentException.class,
+                () -> IggyDynamicTableFactory.parseStartingOffset("specific-offset:-1"));
+    }
+}


### PR DESCRIPTION
Allow new jobs to start consuming from earliest (default), latest, or a specific offset instead of always starting from 0. Restored splits from checkpoints continue to use their persisted offsets.

- Add IggyOffsetPolicy enum and IggyOffsetSpec value object
- Thread offset spec through IggySource builder and IggySplitEnumerator
- Add 'starting-offset' SQL table option to IggyDynamicTableFactory
- Add unit tests for offset spec, SQL parsing, and builder integration
- Update README with DataStream API and Flink SQL usage examples